### PR TITLE
Bugfix: tasks scheduled with long delay may fire too early depending on previous task

### DIFF
--- a/stack/framework/components/timer/timer.c
+++ b/stack/framework/components/timer/timer.c
@@ -335,6 +335,12 @@ static void configure_next_event()
 			//set hw_event_scheduled explicitly to false to allow timer_overflow
 			//to schedule the event when needed
 			NG(hw_event_scheduled) = false;
+
+            // Cancel the timer, it will eventually be re-programmed on overflow.
+            // Note that multiple overflows may happen during one fire_delay.
+            // In that case, the timer is only re-programmed after the last
+            // overflow, so the timer should be canceled in the meantime.
+            hw_timer_cancel(HW_TIMER_ID);
 		}
     }
     timer_busy_programming = false;


### PR DESCRIPTION
If scheduling a long delay (lets say 300 seconds, >> 1 16-bit
overflow) while another task is already schedules, the timer stays
programmed for the first timeout, causing the second task to fire early.


# How to reproduce

The issue seems to trigger if there is at least one task that was planned before and is set to execute almost immediately.
An example (run on STM32L0 platform with timer at 1024 ticks/sec):
```
static void _task_10sec(void* _)
{
    printf("_task_10sec() (t=%lu)\n", timer_get_counter_value());  
}
static void _task_300sec(void* _)
{
    printf("_task_300sec() (t=%lu)\n", timer_get_counter_value());  
}
static void _task_immediate(void* _)
{
    printf("_task_immediate() (t=%lu)\n", timer_get_counter_value());  
}

sched_register_task(&_task_10sec);
sched_register_task(&_task_300sec);
sched_register_task(&_task_immediate);

timer_post_task_delay(&_task_10sec, 10 * TIMER_TICKS_PER_SEC);
timer_post_task_delay(&_task_300sec, 300 * TIMER_TICKS_PER_SEC);
timer_post_task_delay(&_task_immediate, 0);
```

In this case you would expect
- `task_immediate` to be scheduled immediately
-  then `task_10sec` at t=10sec
- then `task_300sec` at t=300.

Instead, `task_300sec` fires early (at most t_task_10sec + 65K ticks):

Debug log:
```
[000] fire_time  <12027>
[001] fire_time  <308987>
[002] timer_post_task_prio counter value <1788>
[003] next_fire_delay <307199>
[004] fire_time  <1788>
[005] timer_post_task_prio counter value <1788>
[006] next_fire_delay <0>
[007] will be late, sched immediately

// Note that the short tasks are OK: within 2 ticks of their fire_time
_task_immediate() (t=1790)
_task_10sec() (t=12028)

// Note that _task_300sec is scheduled at t=77564 instead of 308987
_task_300sec() (t=77564)
```

With bugfix applied:
```
[000] fire_time  <12029>
[001] fire_time  <308989>
[002] timer_post_task_prio counter value <1789>
[003] next_fire_delay <307200>
[004] fire_time  <1790>
[005] timer_post_task_prio counter value <1790>
[006] next_fire_delay <0>
[007] will be late, sched immediately

// Note that all tasks are fired within 2 ticks of their fire_time
_task_immediate() (t=1792)
_task_10sec() (t=12030)
_task_300sec() (t=308989)
```

# Impact

Since this appears to impact all platforms, please review carefully if this can be reproduced and is indeed the best solution.. solution before merging.