### PR TITLE
sched_register_task() may register too many tasks

### DIFF
--- a/stack/framework/components/scheduler/scheduler.c
+++ b/stack/framework/components/scheduler/scheduler.c
@@ -208,7 +208,7 @@ __LINK_C uint8_t get_task_id(task_t task)
 
 __LINK_C error_t sched_register_task(task_t task)
 {
-  assert(NG(num_registered_tasks) <= NUM_TASKS);
+  assert(NG(num_registered_tasks) < NUM_TASKS);
   if(get_task_id(task) != NO_TASK)
     return -EALREADY;
 


### PR DESCRIPTION
`sched_register_task()` checks if `NUM_TASKS` is reached. It seems there is an off-by-one in this check:

## The bug

If `NG(num_registered_tasks) == NUM_TASKS`, no further tasks should be register-able, as all available slots are already claimed. The current implementation returns `SUCCESS` and results in the situation `NG(num_registered_tasks) == (NUM_TASKS+1)`. This also means that the arrays `NG(m_index)` and `NG(m_info)` are accessed out-of-bounds (indexed one past the end).

## How to reproduce

- Register exactly `NUM_TASKS + 1` tasks and observe that no assertion is triggered (though the program may crash due to undefined behaviour).
- Register at least `NUM_TASKS + 2` tasks and observe that the assertion triggers correctly

## Impact

This only impacts firmwares that try to register exactly one task too many, which is probably fairly rare (but can be hard to debug).