### PR TITLE
fix-hw-timer-schedule-infinite-loop

### DIFF
--- a/stack/framework/hal/chips/efm32gg/efm32gg_gpio.c
+++ b/stack/framework/hal/chips/efm32gg/efm32gg_gpio.c
@@ -117,9 +117,6 @@ __LINK_C bool hw_gpio_get_in(pin_id_t pin_id)
 
 static void gpio_int_callback(uint8_t pin)
 {
-    //we use emlib's GPIO interrupt handler which does NOT
-    //disable the interrupts by default --> disable them here to get the same behavior !!
-    start_atomic();
 	assert(interrupts[pin].callback != 0x0);
 	pin_id_t id = {interrupts[pin].interrupt_port, pin};
 	//report an event_mask of '0' since the only way to check which event occurred
@@ -127,7 +124,6 @@ static void gpio_int_callback(uint8_t pin)
     //since the execution of interrupt handlers may be 'delayed' this method is NOT reliable.
     // TODO find out if there is no way to do this reliable on efm32gg
     interrupts[pin].callback(id,0);
-    end_atomic();
 }
 
 __LINK_C error_t hw_gpio_configure_interrupt(pin_id_t pin_id, gpio_inthandler_t callback, uint8_t event_mask)

--- a/stack/framework/hal/chips/efm32lg/efm32lg_gpio.c
+++ b/stack/framework/hal/chips/efm32lg/efm32lg_gpio.c
@@ -120,17 +120,13 @@ __LINK_C bool hw_gpio_get_in(pin_id_t pin_id)
 
 static void gpio_int_callback(uint8_t pin)
 {
-    //we use emlib's GPIO interrupt handler which does NOT
-    //disable the interrupts by default --> disable them here to get the same behavior !!
-    start_atomic();
 	assert(interrupts[pin].callback != 0x0);
-  pin_id_t id = PIN(interrupts[pin].interrupt_port, pin);
+    pin_id_t id = PIN(interrupts[pin].interrupt_port, pin);
 	//report an event_mask of '0' since the only way to check which event occurred
 	//is to check the state of the pin from the interrupt handler and 
     //since the execution of interrupt handlers may be 'delayed' this method is NOT reliable.
     // TODO find out if there is no way to do this reliable on efm32lg
     interrupts[pin].callback(id,0);
-    end_atomic();
 }
 
 __LINK_C error_t hw_gpio_configure_interrupt(pin_id_t pin_id, gpio_inthandler_t callback, uint8_t event_mask)

--- a/stack/framework/hal/chips/ezr32lg/ezr32lg_gpio.c
+++ b/stack/framework/hal/chips/ezr32lg/ezr32lg_gpio.c
@@ -118,17 +118,13 @@ __LINK_C bool hw_gpio_get_in(pin_id_t pin_id)
 
 static void gpio_int_callback(uint8_t pin)
 {
-    //we use emlib's GPIO interrupt handler which does NOT
-    //disable the interrupts by default --> disable them here to get the same behavior !!
-    start_atomic();
 	assert(interrupts[pin].callback != 0x0);
-  pin_id_t id = PIN(interrupts[pin].interrupt_port, pin);
+    pin_id_t id = PIN(interrupts[pin].interrupt_port, pin);
 	//report an event_mask of '0' since the only way to check which event occurred
 	//is to check the state of the pin from the interrupt handler and 
     //since the execution of interrupt handlers may be 'delayed' this method is NOT reliable.
     // TODO find out if there is no way to do this reliable on efm32gg
     interrupts[pin].callback(id,0);
-    end_atomic();
 }
 
 __LINK_C error_t hw_gpio_configure_interrupt(pin_id_t pin_id, gpio_inthandler_t callback, uint8_t event_mask)

--- a/stack/framework/hal/chips/stm32_common/stm32_common_atomic.c
+++ b/stack/framework/hal/chips/stm32_common/stm32_common_atomic.c
@@ -42,3 +42,8 @@ void end_atomic()
   if(nests == 0)
     __enable_irq();
 }
+
+_Bool in_atomic()
+{
+  return (nests > 0);
+}

--- a/stack/framework/hal/chips/stm32_common/stm32_common_gpio.c
+++ b/stack/framework/hal/chips/stm32_common/stm32_common_gpio.c
@@ -198,7 +198,6 @@ __LINK_C bool hw_gpio_get_in(pin_id_t pin_id)
 
 static void gpio_int_callback(uint8_t pin)
 {
-  start_atomic();
   assert(interrupts[pin].isr_ctx.cb != NULL);
   // when interrupting on both edges and when using low power mode where GPIO clocks are disabled we don't know which edge triggered the interrupt.
   // We could enable the clocks to read in the current GPIO level but most drivers and apps do not need to know this or can determine this based on state.
@@ -207,7 +206,6 @@ static void gpio_int_callback(uint8_t pin)
   // For this reason we pass 0 to the event_mask param of the callback.
   // TODO when only one interrupt edge is configured we _can_ reliably determine the edge so this can be improved
   interrupts[pin].isr_ctx.cb(interrupts[pin].isr_ctx.arg);
-  end_atomic();
 }
 
 __LINK_C error_t hw_gpio_set_edge_interrupt(pin_id_t pin_id, uint8_t edge)

--- a/stack/framework/hal/chips/stm32_common/stm32_common_timer.c
+++ b/stack/framework/hal/chips/stm32_common/stm32_common_timer.c
@@ -183,6 +183,7 @@ error_t hw_timer_schedule(hwtimer_id_t timer_id, hwtimer_tick_t tick )
  		return EOFF;
   //don't enable the interrupt while waiting to write a new compare value
   ready_for_trigger = false;
+  assert(!in_atomic()); // if we currently are in atomic context it is possible to have an infinite loop on the instruction below.
   while(cmp_reg_write_pending); // prev write operation is pending, writing again before may give unpredicatable results (see datasheet), so block here
   ready_for_trigger = true;
   start_atomic();

--- a/stack/framework/hal/inc/hwatomic.h
+++ b/stack/framework/hal/inc/hwatomic.h
@@ -77,6 +77,12 @@ __LINK_C void start_atomic(void);
  */
 __LINK_C void end_atomic(void);
 
+/*! \brief Check if currently in atomic section
+ *
+ * Indicates whether we are currently in an atomic section
+ */
+__LINK_C _Bool in_atomic(void);
+
 #endif //__HW_ATOMIC_H_
 
 /** @}*/


### PR DESCRIPTION
The atomic section in gpio_int_callback in some cases prevents gpio interrupts from scheduling timer tasks.
The atomic section prevents the timer interrupt from firing which may cause an infinite loop on: https://github.com/Sub-IoT/Sub-IoT-Stack/blob/9b8ce55882a8d1df857edd4190c150d599b511e6/stack/framework/hal/chips/stm32_common/stm32_common_timer.c#L186