### PR TITLE
added error exception for type-limits to fix bug with num_leds=0

### DIFF
--- a/stack/cmake/toolchains/gcc-arm-embedded.cmake
+++ b/stack/cmake/toolchains/gcc-arm-embedded.cmake
@@ -41,8 +41,8 @@ SET(CMAKE_SYSTEM_VERSION 1)
 SET(CMAKE_CROSSCOMPILING 1)
 
 # set compiler flags to optimize for code size
-SET(CMAKE_C_FLAGS_DEBUG "-Og -Werror -Wcast-align=strict -Wall -Wno-unused -Wno-maybe-uninitialized -Wno-switch -Wno-return-type -Wpacked-not-aligned -Wshadow -Wextra" CACHE STRING "")
-SET(CMAKE_C_FLAGS_RELEASE "-Og -Werror -Wcast-align=strict -Wall -Wno-unused -Wno-maybe-uninitialized -Wno-switch -Wno-return-type -Wpacked-not-aligned -Wshadow -Wextra" CACHE STRING "")
+SET(CMAKE_C_FLAGS_DEBUG "-Og -Werror -Wcast-align=strict -Wall -Wno-unused -Wno-maybe-uninitialized -Wno-switch -Wno-return-type -Wpacked-not-aligned -Wshadow -Wextra -Wno-type-limits" CACHE STRING "")
+SET(CMAKE_C_FLAGS_RELEASE "-Og -Werror -Wcast-align=strict -Wall -Wno-unused -Wno-maybe-uninitialized -Wno-switch -Wno-return-type -Wpacked-not-aligned -Wshadow -Wextra -Wno-type-limits" CACHE STRING "")
 
 # set C++ compiler flags to the same as the C compiler flags, but with some -Wno-error flags because of more restrictive
 # C++ compiler behaviour.


### PR DESCRIPTION
When using a platform without LEDs or put ccmake option `PLATFORM_NUM_LEDS` to 0, the stack refuses to build.
This issue was introduced by adding the `-Wextra` flag in commit 08accc2fde84c80280e470cb5d290b8eb4457fc8 which considers statements that are always true or false as a potential mistake and throws a warning at compile time. However, the -Wextra flag turns this warning into an error, preventing `make` from completing.
Adding an exception `-Wno-type-limits` fixes this warning from failing builds on platforms without LEDs.

<img width="1425" alt="Screenshot 2022-06-11 at 00 19 31" src="https://user-images.githubusercontent.com/5693589/173160402-dc2d8651-ffa6-4746-b37a-83d4c1ad3cb8.png">
