### PR TITLE
D7AP: switch from SLAVE_PENDING_MASTER to MASTER instead of IDLE

### DIFF
--- a/stack/modules/d7ap/d7asp.c
+++ b/stack/modules/d7ap/d7asp.c
@@ -842,9 +842,18 @@ void d7asp_signal_dialog_terminated()
     if (current_master_session.state == D7ASP_MASTER_SESSION_PENDING_DORMANT_TRIGGERED) {
       switch_state(D7ASP_STATE_PENDING_MASTER);
       schedule_current_session();
+      d7ap_stack_signal_slave_session_terminated();
+
+    } else if (d7asp_state == D7ASP_STATE_SLAVE_PENDING_MASTER) {
+        d7ap_stack_signal_slave_session_terminated();
+
+        switch_state(D7ASP_STATE_MASTER);
+        d7ap_stack_signal_active_master_session(current_master_session.token);
+        schedule_current_session();
+
     } else {
       switch_state(D7ASP_STATE_IDLE);
+      d7ap_stack_signal_slave_session_terminated();
     }
 
-    d7ap_stack_signal_slave_session_terminated();
 }


### PR DESCRIPTION
In our application we have onee DASH7 node acting as a gateway, which both transmits (background) data and receives unsolicited data from other nodes. When both happen at the same time, something goes wrong as described below.

A gateway may start sending data while a dialog with one of the nodes is still active. In this case the D7AP switches to `D7ASP_STATE_SLAVE_PENDING_MASTER`.

When the dialog in the slave session completes, the master session would stay pending forever. This in turn would mean the ALP layer would 'leak' a transfer (completion callback never fires, command would never get deallocated).

This patch modifies the D7ASP state machine so that `D7ASP_STATE_SLAVE_PENDING_MASTER` switches to `D7ASP_STATE_MASTER` as soon as the slave dialog closes. So far I have never been able to get a successful response to this master transaction, but at least the ALP layer recovers to a usable state.